### PR TITLE
Request body validation middleware

### DIFF
--- a/src/controllers/exerciseController.ts
+++ b/src/controllers/exerciseController.ts
@@ -1,7 +1,6 @@
 import { Response } from 'express';
-import { ExerciseModel } from '../models';
-import { exerciseSchema } from '../validations/schema';
 import { ZodError } from 'zod';
+import { ExerciseModel } from '../models';
 import { formatDateToString } from '../utils/dateUtils';
 import { RequestWithUser } from '../interfaces/request';
 
@@ -17,8 +16,7 @@ export class ExerciseController {
       }
 
       const user = req.user;
-
-      const exerciseData = exerciseSchema.parse(req.body);
+      const exerciseData = req.body;
       const newExercise = await this.exerciseModel.createExercise(
         user._id,
         exerciseData,

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -1,14 +1,12 @@
 import { Request, Response } from 'express';
 import { UserModel } from '../models/userModel';
-import { userSchema } from '../validations/schema';
 
 export class UserController {
   constructor(private userModel: UserModel) {}
 
   async createUser(req: Request, res: Response) {
     try {
-      console.log('Creating user with data:', req.body);
-      const { username } = userSchema.parse(req.body);
+      const { username } = req.body;
       const user = await this.userModel.createUser(username);
       res.status(201).json(user);
     } catch (error) {

--- a/src/middlewares/validateBody.ts
+++ b/src/middlewares/validateBody.ts
@@ -1,0 +1,23 @@
+import { Request, Response, NextFunction } from 'express';
+import { ZodSchema, ZodError } from 'zod';
+
+export const validateBody = (schema: ZodSchema) => {
+  return (req: Request, res: Response, next: NextFunction) => {
+    try {
+      req.body = schema.parse(req.body);
+      next();
+    } catch (error) {
+      if (error instanceof ZodError) {
+        res.status(400).json({ 
+          error: 'Validation failed',
+          details: error.issues.map(issue => ({
+            field: issue.path.join('.'),
+            message: issue.message
+          }))
+        });
+        return;
+      }
+      next(error);
+    }
+  };
+};

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -2,7 +2,9 @@ import { RequestHandler, Router } from 'express';
 import { UserController } from '../controllers/userController';
 import { ExerciseController } from '../controllers/exerciseController';
 import { checkUserExists } from '../middlewares/checkUserExists';
+import { validateBody } from '../middlewares/validateBody';
 import { UserModel } from '../models/userModel';
+import { exerciseSchema, userSchema } from '../validations/schema';
 
 export function createApiRoutes(
   userController: UserController,
@@ -11,12 +13,19 @@ export function createApiRoutes(
 ) {
   const router = Router();
 
-  router.post('/users', userController.createUser.bind(userController));
+  router.post(
+    '/users',
+    validateBody(userSchema),
+    userController.createUser.bind(userController),
+  );
   router.get('/users', userController.getUsers.bind(userController));
   router.post(
     '/users/:_id/exercises',
+    validateBody(exerciseSchema),
     checkUserExists(userModel) as unknown as RequestHandler,
-    exerciseController.createExercise.bind(exerciseController) as unknown as RequestHandler,
+    exerciseController.createExercise.bind(
+      exerciseController,
+    ) as unknown as RequestHandler,
   );
 
   return router;


### PR DESCRIPTION
Introduced a reusable validateBody middleware using Zod for validating request bodies. Updated user and exercise creation routes to use this middleware, removing inline schema parsing from controllers for cleaner separation of concerns.